### PR TITLE
[ROC-7] Fix paypal data collector

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -32,9 +32,9 @@ repositories {
 }
 
 dependencies {
-    implementation 'com.braintreepayments.api:drop-in:6.7.0'
+    implementation 'com.braintreepayments.api:drop-in:6.16.0'
     implementation 'com.facebook.react:react-native:+'
-    implementation 'com.braintreepayments.api:three-d-secure:4.23.1'
-    implementation 'com.braintreepayments.api:card:4.23.1'
+    implementation 'com.braintreepayments.api:three-d-secure:4.45.0'
+    implementation 'com.braintreepayments.api:card:4.45.0'
     implementation 'com.google.android.gms:play-services-wallet:19.1.0'
 }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -5,19 +5,19 @@ buildscript {
     }
 
     dependencies {
-         classpath 'com.android.tools.build:gradle:4.1.3'
+         classpath 'com.android.tools.build:gradle:7.4.1'
     }
 }
 
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 31
-    buildToolsVersion "30.0.2"
+    compileSdkVersion 34
+    buildToolsVersion "34.0.0"
 
     defaultConfig {
         minSdkVersion 21
-        targetSdkVersion 31
+        targetSdkVersion 34
         versionCode 3
         versionName "1.3.2"
     }


### PR DESCRIPTION
# Description
Based on these google play store complaints:

<img width="641" alt="Screenshot 2024-07-12 at 14 17 23" src="https://github.com/user-attachments/assets/5c2aeb52-f4e1-49e2-af8a-518988ad1207">

There is an issue in the braintree drop-in sdk that addresses this problem => [issue](https://github.com/braintree/braintree_android/issues/931#issuecomment-2075044147) in which indicates that is something they have solved in braintreepayments.api:drop-in version 6.16.0 and braintreepayments:api version 4.45

This task addresses both updates including a bump on the android targetSdkVersion in order to be compatible with the new update in user-mobile code.